### PR TITLE
allow to work in subdirs of the repository

### DIFF
--- a/tests_selector/utils/git.py
+++ b/tests_selector/utils/git.py
@@ -1,13 +1,21 @@
 import re
+import subprocess
 
 from pydriller import GitRepository
 
 
 def get_git_repo(project_folder):
-    return GitRepository("./" + project_folder)
+    if not project_folder:
+        res = subprocess.run(
+            "git rev-parse --show-toplevel".split(" "),
+            check=True,
+            capture_output=True,
+        )
+        project_folder = res.stdout.decode().rstrip()
+    return GitRepository(project_folder)
 
 
-def changed_files_branch(project_folder="."):
+def changed_files_branch(project_folder=None):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("--name-only", "master...").split()
 
@@ -17,22 +25,24 @@ def file_changes_between_commits(commit1, commit2, project_folder):
     return repo.repo.git.diff("--name-only", commit1, commit2).split()
 
 
-def changed_files_current(project_folder="."):
+def changed_files_current(project_folder=None):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("--name-only").split()
 
 
-def file_diff_data_branch(filename, project_folder="."):
+def file_diff_data_branch(filename, project_folder=None):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", "master...", "--", filename)
 
 
-def file_diff_data_between_commits(filename, commithash1, commithash2, project_folder):
+def file_diff_data_between_commits(
+    filename, commithash1, commithash2, project_folder
+):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", commithash1, commithash2, "--", filename)
 
 
-def file_diff_data_current(filename, project_folder="."):
+def file_diff_data_current(filename, project_folder=None):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", "--", filename)
 


### PR DESCRIPTION
tests_selector expects that it is run from the root of the repository.
However, there are situations when the code under test resides in some
subdirectory of the project. This change uses git to find the root.