### PR TITLE
fix error in test duration

### DIFF
--- a/tests_selector/utils/db.py
+++ b/tests_selector/utils/db.py
@@ -311,7 +311,7 @@ def get_test_duration(testname):
     data = c.execute(
         "SELECT duration FROM test_function WHERE context = ?", (testname,)
     ).fetchone()
-    if data == None or (None,):
+    if data == None or data == (None,):
         duration = 99999
     else:
         duration = data[0]


### PR DESCRIPTION
While addressing  #16 I noticed an error with duration value of `None` crashing the `tests_selector` again