### PR TITLE
Change test selection to look at previous update hash

### DIFF
--- a/tests_selector/utils/common.py
+++ b/tests_selector/utils/common.py
@@ -4,50 +4,21 @@ import subprocess
 from tests_selector.utils.git import (
     file_diff_data_between_commits,
     file_diff_data_current,
-    file_diff_data_branch,
-    file_diff_data_since_last_commit,
     get_test_lines_and_update_lines,
 )
 
 
-def file_diff_dict_since_last_commit(files):
+def file_diff_dict_current(files):
+    """Returns a dictionary with file id as key and git diff as value"""
+    return {file_id: file_diff_data_current(filename) for file_id, filename in files}
+
+
+def file_diff_dict_between_commits(files, commithash1, commithash2):
     """Returns a dictionary with file id as key and git diff as value"""
     return {
-        file_id: file_diff_data_since_last_commit(filename)
+        file_id: file_diff_data_between_commits(filename, commithash1, commithash2)
         for file_id, filename in files
     }
-
-
-def file_diff_dict_branch(files):
-    diff_dict = {}
-    for f in files:
-        file_id = f[0]
-        filename = f[1]
-        diff = file_diff_data_branch(filename)
-        diff_dict[file_id] = diff
-    return diff_dict
-
-
-def file_diff_dict_current(files):
-    diff_dict = {}
-    for f in files:
-        file_id = f[0]
-        filename = f[1]
-        diff = file_diff_data_current(filename)
-        diff_dict[file_id] = diff
-    return diff_dict
-
-
-def file_diff_dict_between_commits(files, commithash1, commithash2, project_folder):
-    diff_dict = {}
-    for f in files:
-        file_id = f[0]
-        filename = f[1]
-        diff = file_diff_data_between_commits(
-            filename, commithash1, commithash2, project_folder
-        )
-        diff_dict[file_id] = diff
-    return diff_dict
 
 
 def tests_from_changed_testfiles(diff_dict, files, db):

--- a/tests_selector/utils/db.py
+++ b/tests_selector/utils/db.py
@@ -148,8 +148,7 @@ class DatabaseHelper:
         self.db_cursor.execute("DROP TABLE IF EXISTS test_file")
         self.db_cursor.execute("DROP TABLE IF EXISTS test_function")
         self.db_cursor.execute("DROP TABLE IF EXISTS new_tests")
-        self.db_cursor.execute("DROP TABLE IF EXISTS comparisons")
-        self.db_cursor.execute("DROP TABLE IF EXISTS init_hash")
+        self.db_cursor.execute("DROP TABLE IF EXISTS last_update_hash")
         self.db_cursor.execute(
             "CREATE TABLE test_map (file_id INTEGER, test_function_id INTEGER, line_id INTEGER, UNIQUE(file_id,test_function_id,line_id))"
         )
@@ -171,10 +170,7 @@ class DatabaseHelper:
                                 UNIQUE (context))"""
         )
         self.db_cursor.execute("CREATE TABLE new_tests (context TEXT)")
-        self.db_cursor.execute(
-            "CREATE TABLE comparisons (hash1 TEXT, hash2 TEXT, UNIQUE(hash1, hash2))"
-        )
-        self.db_cursor.execute("CREATE TABLE init_hash (hash TEXT)")
+        self.db_cursor.execute("CREATE TABLE last_update_hash (hash TEXT)")
         self.db_conn.commit()
 
     def save_mapping_lines(self, src_id, test_function_id, lines):
@@ -244,25 +240,19 @@ class DatabaseHelper:
             ).fetchone()[0]
         )
 
-    def comparison_exists(self, hash1, hash2):
-        return bool(
-            self.db_cursor.execute(
-                "SELECT EXISTS(SELECT * FROM comparisons WHERE hash1 = ? AND hash2 = ?)",
-                (hash1, hash2),
-            ).fetchone()[0]
-        )
-
-    def save_comparison(self, hash1, hash2):
-        self.db_cursor.execute("INSERT INTO comparisons VALUES (?,?)", (hash1, hash2))
+    def save_last_update_hash(self, commithash):
+        self.db_cursor.execute("DELETE FROM last_update_hash")
+        self.db_cursor.execute("INSERT INTO last_update_hash VALUES (?)", (commithash,))
         self.db_conn.commit()
 
-    def save_init_hash(self, inithash):
-        self.db_cursor.execute("INSERT INTO init_hash VALUES (?)", (inithash,))
-        self.db_conn.commit()
-
-    def is_init_hash(self, commithash):
-        db_hash = self.db_cursor.execute("SELECT hash FROM init_hash").fetchone()[0]
+    def is_last_update_hash(self, commithash):
+        db_hash = self.db_cursor.execute(
+            "SELECT hash FROM last_update_hash"
+        ).fetchone()[0]
         return db_hash == commithash
+
+    def get_last_update_hash(self):
+        return self.db_cursor.execute("SELECT hash FROM last_update_hash").fetchone()[0]
 
 
 class ResultDatabaseHelper:

--- a/tests_selector/utils/git.py
+++ b/tests_selector/utils/git.py
@@ -15,12 +15,7 @@ def get_git_repo(project_folder):
     return GitRepository(project_folder)
 
 
-def changed_files_branch(project_folder=None):
-    repo = get_git_repo(project_folder)
-    return repo.repo.git.diff("--name-only", "master...").split()
-
-
-def file_changes_between_commits(commit1, commit2, project_folder):
+def changed_files_between_commits(commit1, commit2, project_folder=None):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("--name-only", commit1, commit2).split()
 
@@ -30,12 +25,9 @@ def changed_files_current(project_folder=None):
     return repo.repo.git.diff("--name-only").split()
 
 
-def file_diff_data_branch(filename, project_folder=None):
-    repo = get_git_repo(project_folder)
-    return repo.repo.git.diff("-U0", "master...", "--", filename)
-
-
-def file_diff_data_between_commits(filename, commithash1, commithash2, project_folder):
+def file_diff_data_between_commits(
+    filename, commithash1, commithash2, project_folder=None
+):
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", commithash1, commithash2, "--", filename)
 
@@ -46,6 +38,7 @@ def file_diff_data_current(filename, project_folder=None):
 
 
 def get_test_lines_and_update_lines(diff):
+    """Parse changed lines, line number updates and new lines from git diff -U0 output"""
     regex = r"[@][@]\s+[-][0-9]+(?:,[0-9]+)?\s+[+][0-9]+(?:,[0-9]+)?\s+[@][@]"
     line_changes = re.findall(regex, diff)
     lines_to_query = []
@@ -94,22 +87,6 @@ def get_test_lines_and_update_lines(diff):
     return lines_to_query, updates_to_lines, new_lines
 
 
-def get_head_and_previous_hash():
-    git_data = get_git_repo(None).repo.git.rev_list("--parents", "-n 1", "HEAD").split()
-    if len(git_data) == 1:
-        head = git_data[0]
-        previous = None
-    else:
-        head = git_data[0]
-        previous = git_data[1]
-    return head, previous
-
-
-def changed_files_since_last_commit(project_folder=None):
-    repo = get_git_repo(project_folder)
-    return repo.repo.git.diff("--name-only", "HEAD^").split()
-
-
-def file_diff_data_since_last_commit(filename, project_folder=None):
-    repo = get_git_repo(project_folder)
-    return repo.repo.git.diff("-U0", "HEAD^", "--", filename)
+def get_current_head_hash():
+    """Return current git HEAD hash"""
+    return get_git_repo(None).repo.head.object.hexsha


### PR DESCRIPTION
* Database only stores hash for the commit when the database was last updated
  * Checking committed changes -> changes extracted with `git diff last_update_hash...current_hash` 
  * Update the hash when running any updates
  * Error detection (hash missing etc.) later?
* Removed the other diff functions (like `changed_files_branch` & `diff_dict_branch`) to not confuse anyone
* Added some docstrings for functions that I touched and where it seemed like a good idea
* Should solve the problem shown in #32  