### PR TITLE
refactor: change code to pass pylint and mypy

### DIFF
--- a/tests_selector/init.py
+++ b/tests_selector/init.py
@@ -1,9 +1,10 @@
+"""This module contains code for running pytest with InitPhasePlugin"""
 import pytest
-
 from tests_selector.pytest.init_phase_plugin import InitPhasePlugin
 
 
 def main():
+    """Run pytest with InitPhasePlugin"""
     pytest.main([], plugins=[InitPhasePlugin()])
 
 

--- a/tests_selector/pytest/capture_specific_plugin.py
+++ b/tests_selector/pytest/capture_specific_plugin.py
@@ -1,17 +1,18 @@
-from tests_selector.pytest.fake_item import FakeItem
+"""This module contains code for capturing pytest exit code for running a test set"""
 
 
-class CaptureSpecificPlugin:
+class CaptureSpecificPlugin:  # pylint: disable=too-few-public-methods
+    """Plugin class for pytest"""
+
     def __init__(self, test_set):
+        """Set test set as a value"""
         self.test_set = test_set
 
     def pytest_collection_modifyitems(self, session, config, items):
-        original_length = len(items)
+        """Only select specific tests for running"""
+        del session, config
         selected = []
         for item in items:
             if item.nodeid in self.test_set:
                 selected.append(item)
         items[:] = selected
-        session.config.hook.pytest_deselected(
-            items=([FakeItem(session.config)] * (original_length - len(selected)))
-        )

--- a/tests_selector/pytest/collect_plugin.py
+++ b/tests_selector/pytest/collect_plugin.py
@@ -1,9 +1,17 @@
-class CollectPlugin:
+"""This module contains code for collecting newly added tests"""
+
+
+class CollectPlugin:  # pylint: disable=too-few-public-methods
+    """Plugin class for pytest"""
+
     def __init__(self, existing_tests):
+        """Set test set that exists in database as value"""
         self.collected = []
         self.existing_tests = existing_tests
 
-    def pytest_collection_modifyitems(self, items):
+    def pytest_collection_modifyitems(self, session, config, items):
+        """Select tests that have not been previously seen"""
+        del session, config
         for item in items:
             if item.nodeid not in self.existing_tests:
                 self.collected.append(item.nodeid)

--- a/tests_selector/pytest/fake_item.py
+++ b/tests_selector/pytest/fake_item.py
@@ -1,3 +1,8 @@
-class FakeItem(object):
+"""This module contains a fake pytest item class"""
+
+
+class FakeItem:  # pylint: disable=too-few-public-methods
+    """Fake class"""
+
     def __init__(self, config):
         self.config = config

--- a/tests_selector/pytest/normal_phase_plugin.py
+++ b/tests_selector/pytest/normal_phase_plugin.py
@@ -1,27 +1,33 @@
-import pytest
-from tests_selector.pytest.fake_item import FakeItem
+"""This module contains code for running a specific test set without mapping database updating"""
 from tests_selector.utils.db import DatabaseHelper
+from tests_selector.pytest.fake_item import FakeItem
 
 
 class NormalPhasePlugin:
+    """Plugin class for pytest"""
+
     def __init__(self, test_set):
+        """Initialize database connection"""
         self.test_func_times = {}
         self.test_set = test_set
-        self.db = DatabaseHelper()
-        self.db.init_conn()
+        self.database = DatabaseHelper()
+        self.database.init_conn()
         self.fill_times_dict()
 
     def fill_times_dict(self):
+        """Query running times of tests from database"""
         for testname in self.test_set:
-            self.test_func_times[testname] = self.db.get_test_duration(testname)
+            self.test_func_times[testname] = self.database.get_test_duration(testname)
 
     def pytest_collection_modifyitems(self, session, config, items):
+        """Select only specific tests for running and prioritize them based on queried times"""
+        del config
         original_length = len(items)
         selected = []
         for item in items:
             if item.nodeid in self.test_set:
                 selected.append(item)
-        # sort tests based on duration value from database
+
         items[:] = sorted(selected, key=lambda item: self.test_func_times[item.nodeid])
 
         session.config.hook.pytest_deselected(

--- a/tests_selector/run.py
+++ b/tests_selector/run.py
@@ -1,10 +1,11 @@
-import pytest
+"""This module contains code for running pytest with NormalPhasePlugin"""
 import sys
-
+import pytest
 from tests_selector.pytest.normal_phase_plugin import NormalPhasePlugin
 
 
 def main():
+    """Run pytest with NormalPhasePlugin and a given test set"""
     test_set = set(sys.argv[1:])
     pytest.main([], plugins=[NormalPhasePlugin(test_set)])
 

--- a/tests_selector/run_and_update.py
+++ b/tests_selector/run_and_update.py
@@ -1,10 +1,11 @@
-import pytest
+"""This module contains code for running pytest with UpdatePhasePlugin"""
 import sys
-
+import pytest
 from tests_selector.pytest.update_phase_plugin import UpdatePhasePlugin
 
 
 def main():
+    """Run pytest with UpdatePhasePlugin and a given test set"""
     test_set = set(sys.argv[1:])
     pytest.main([], plugins=[UpdatePhasePlugin(test_set)])
 

--- a/tests_selector/select.py
+++ b/tests_selector/select.py
@@ -1,6 +1,8 @@
+"""This module contains code for the main functionality of the RTS tool"""
 import logging
 import os
 import subprocess
+import sys
 from typing import Dict, List, NamedTuple, Set
 from tests_selector.utils.common import (
     file_diff_dict_between_commits,
@@ -21,27 +23,43 @@ from tests_selector.utils.db import (
     DB_FILE_NAME,
 )
 
-
+# https://github.com/PyCQA/pylint/issues/3876
+# pylint: disable=inherit-non-class
+# pylint: disable=too-few-public-methods
 class UpdateData(NamedTuple):
+    """NamedTuple for mapping database update data"""
+
     changed_lines_test: Dict[str, List[int]]
     new_line_map_test: Dict[int, int]
     changed_lines_src: Dict[str, List[int]]
     new_line_map_src: Dict[int, int]
 
 
+# pylint: disable=inherit-non-class
+# pylint: disable=too-few-public-methods
 class TestsAndDataFromChanges(NamedTuple):
+    """NamedTuple for tests and update data from changes"""
+
     test_set: Set[str]
     update_data: UpdateData
     files_to_warn: List[str]
 
 
+# pylint: disable=inherit-non-class
+# pylint: disable=too-few-public-methods
 class TestsAndDataCurrent(NamedTuple):
+    """NamedTuple for tests and statistics data from working directory changes"""
+
     test_set: Set[str]
     changed_testfiles_amount: int
     changed_srcfiles_amount: int
 
 
+# pylint: disable=inherit-non-class
+# pylint: disable=too-few-public-methods
 class TestsAndDataCommitted(NamedTuple):
+    """NamedTuple for tests, statistics and update data from committed changes"""
+
     test_set: Set[str]
     update_data: UpdateData
     changed_testfiles_amount: int
@@ -52,7 +70,7 @@ class TestsAndDataCommitted(NamedTuple):
 
 
 def get_tests_from_changes(
-    test_file_diffs, src_file_diffs, testfiles, srcfiles, db
+    test_file_diffs, src_file_diffs, testfiles, srcfiles, db_helper
 ) -> TestsAndDataFromChanges:
     """Returns the test set and data required for line shifting"""
     (
@@ -60,13 +78,13 @@ def get_tests_from_changes(
         changed_lines_src,
         new_line_map_src,
         files_to_warn,
-    ) = tests_from_changed_srcfiles(src_file_diffs, srcfiles, db)
+    ) = tests_from_changed_srcfiles(src_file_diffs, srcfiles, db_helper)
 
     (
         test_test_set,
         changed_lines_test,
         new_line_map_test,
-    ) = tests_from_changed_testfiles(test_file_diffs, testfiles, db)
+    ) = tests_from_changed_testfiles(test_file_diffs, testfiles, db_helper)
 
     test_set = test_test_set.union(src_test_set)
 
@@ -82,16 +100,20 @@ def get_tests_from_changes(
     )
 
 
-def get_tests_and_data_current(db) -> TestsAndDataCurrent:
+def get_tests_and_data_current(db_helper) -> TestsAndDataCurrent:
     """Returns the test set from working directory changes and data for printing statistics"""
     changed_files = changed_files_current()
-    changed_test_files, changed_src_files = split_changes(changed_files, db)
+    changed_test_files, changed_src_files = split_changes(changed_files, db_helper)
 
     src_file_diffs = file_diff_dict_current(changed_src_files)
     test_file_diffs = file_diff_dict_current(changed_test_files)
 
     changes = get_tests_from_changes(
-        test_file_diffs, src_file_diffs, changed_test_files, changed_src_files, db
+        test_file_diffs,
+        src_file_diffs,
+        changed_test_files,
+        changed_src_files,
+        db_helper,
     )
 
     return TestsAndDataCurrent(
@@ -101,15 +123,15 @@ def get_tests_and_data_current(db) -> TestsAndDataCurrent:
     )
 
 
-def get_tests_and_data_committed(db) -> TestsAndDataCommitted:
+def get_tests_and_data_committed(db_helper) -> TestsAndDataCommitted:
     """Compares current git HEAD has to previous update state commit hash
     Returns the test set and data required for line-shifting and printing statistics
     """
     current_hash = get_current_head_hash()
-    previous_hash = db.get_last_update_hash()
+    previous_hash = db_helper.get_last_update_hash()
 
     changed_files = changed_files_between_commits(previous_hash, current_hash)
-    changed_test_files, changed_src_files = split_changes(changed_files, db)
+    changed_test_files, changed_src_files = split_changes(changed_files, db_helper)
 
     src_file_diffs = file_diff_dict_between_commits(
         changed_src_files, previous_hash, current_hash
@@ -118,13 +140,17 @@ def get_tests_and_data_committed(db) -> TestsAndDataCommitted:
         changed_test_files, previous_hash, current_hash
     )
 
-    new_tests = read_newly_added_tests(db)
+    new_tests = read_newly_added_tests(db_helper)
     changes = get_tests_from_changes(
-        test_file_diffs, src_file_diffs, changed_test_files, changed_src_files, db
+        test_file_diffs,
+        src_file_diffs,
+        changed_test_files,
+        changed_src_files,
+        db_helper,
     )
     full_test_set = changes.test_set.union(new_tests)
 
-    warning_needed = changes.files_to_warn and not new_tests
+    warning_needed = bool(changes.files_to_warn and not new_tests)
 
     return TestsAndDataCommitted(
         test_set=full_test_set,
@@ -138,47 +164,51 @@ def get_tests_and_data_committed(db) -> TestsAndDataCommitted:
 
 
 def main():
+    """Run tool by first checking git working directory changes and then committed changes"""
     logger = logging.getLogger()
     logging.basicConfig(format="%(message)s", level=logging.INFO)
 
     if not os.path.isfile(DB_FILE_NAME):
         logger.info("Run tests_selector_init first")
-        exit(1)
+        sys.exit()
 
-    db = DatabaseHelper()
-    db.init_conn()
+    db_helper = DatabaseHelper()
+    db_helper.init_conn()
 
-    workdir_data = get_tests_and_data_current(db)
+    workdir_data = get_tests_and_data_current(db_helper)
 
     logger.info("WORKING DIRECTORY CHANGES")
-    logger.info(f"Found {workdir_data.changed_testfiles_amount} changed test files")
-    logger.info(f"Found {workdir_data.changed_srcfiles_amount} changed src files")
-    logger.info(f"Found {len(workdir_data.test_set)} tests to execute\n")
+    logger.info("Found %s changed test files", workdir_data.changed_testfiles_amount)
+    logger.info("Found %s changed src files", workdir_data.changed_srcfiles_amount)
+    logger.info("Found %s tests to execute\n", len(workdir_data.test_set))
 
     if workdir_data.test_set:
         logger.info(
             "Running WORKING DIRECTORY test set and exiting without updating..."
         )
-        subprocess.run(["tests_selector_run"] + list(workdir_data.test_set))
-        exit()
+        subprocess.run(["tests_selector_run"] + list(workdir_data.test_set), check=True)
+        sys.exit()
 
     logger.info("No WORKING DIRECTORY tests to run, checking COMMITTED changes...")
     current_hash = get_current_head_hash()
-    if db.is_last_update_hash(current_hash):
+    if db_helper.is_last_update_hash(current_hash):
         logger.info("Database is updated to the current commit state")
         logger.info("=> Skipping test discovery, execution and updating")
-        exit()
+        sys.exit()
 
-    previous_hash = db.get_last_update_hash()
-    logger.info(f"Comparison: {current_hash} => {previous_hash}\n")
+    previous_hash = db_helper.get_last_update_hash()
+    logger.info("Comparison: %s\n", " => ".join([current_hash, previous_hash]))
 
-    committed_data = get_tests_and_data_committed(db)
+    committed_data = get_tests_and_data_committed(db_helper)
 
     logger.info("COMMITTED CHANGES")
-    logger.info(f"Found {committed_data.changed_testfiles_amount} changed test files")
-    logger.info(f"Found {committed_data.changed_srcfiles_amount} changed src files")
-    logger.info(f"Found {committed_data.new_tests_amount} newly added tests")
-    logger.info(f"Found {len(committed_data.test_set)} tests to execute\n")
+    logger.info("Found %s changed test files", committed_data.changed_testfiles_amount)
+    logger.info("Found %s changed src files", committed_data.changed_srcfiles_amount)
+    logger.info(
+        "Found %s newly added tests",
+        committed_data.new_tests_amount,
+    )
+    logger.info("Found %s tests to execute\n", len(committed_data.test_set))
     if committed_data.warning_needed:
         logger.info(
             "WARNING: New lines were added to the following files but no new tests discovered:"
@@ -186,10 +216,12 @@ def main():
         logger.info("\n".join(committed_data.files_to_warn))
 
     logger.info("=> Executing tests (if any) and updating database")
-    db.save_last_update_hash(current_hash)
-    run_tests_and_update_db(committed_data.test_set, committed_data.update_data, db)
+    db_helper.save_last_update_hash(current_hash)
+    run_tests_and_update_db(
+        committed_data.test_set, committed_data.update_data, db_helper
+    )
 
-    db.close_conn()
+    db_helper.close_conn()
 
 
 if __name__ == "__main__":

--- a/tests_selector/utils/db.py
+++ b/tests_selector/utils/db.py
@@ -1,23 +1,29 @@
+"""This module contains code for database actions"""
 import sqlite3
 
 DB_FILE_NAME = "mapping.db"
 
 
 class DatabaseHelper:
+    """Class for database actions"""
+
     def __init__(self):
         self.db_conn = None
         self.db_cursor = None
 
-    def init_conn(self, new=False):
+    def init_conn(self):
+        """Connect to sqlite database and set cursor"""
         self.db_conn = sqlite3.connect(DB_FILE_NAME)
         self.db_cursor = self.db_conn.cursor()
 
     def close_conn(self):
+        """Disconnect sqlite and remove cursor"""
         self.db_conn.close()
         self.db_conn = None
         self.db_cursor = None
 
     def delete_ran_lines(self, line_ids, file_id):
+        """Delete all test_map rows for given lines and file"""
         for line in line_ids:
             self.db_cursor.execute(
                 "DELETE FROM test_map WHERE line_id == ? AND file_id == ?",
@@ -26,11 +32,14 @@ class DatabaseHelper:
         self.db_conn.commit()
 
     def update_db_from_src_mapping(self, line_map, file_id):
-        # this should update test mapping line data of src files to new line numbers calculated from changes
+        """Delete old source code file mapping data and insert updated"""
         tests_to_update = []
         for line_id in line_map.keys():
             db_data = self.db_cursor.execute(
-                "SELECT file_id,test_function_id,line_id FROM test_map WHERE line_id == ? AND file_id == ?",
+                """
+                SELECT file_id,test_function_id,line_id
+                FROM test_map WHERE line_id == ? AND file_id == ?
+                """,
                 (line_id, file_id),
             )
             for line in db_data:
@@ -39,16 +48,16 @@ class DatabaseHelper:
                 "DELETE FROM test_map WHERE line_id == ? AND file_id == ?",
                 (line_id, file_id),
             )
-        for t in tests_to_update:
-            updated_t = (t[0], t[1], line_map[t[2]])
+        for test in tests_to_update:
+            updated_test = (test[0], test[1], line_map[test[2]])
             self.db_cursor.execute(
                 "INSERT OR IGNORE INTO test_map (file_id,test_function_id,line_id) VALUES (?,?,?)",
-                updated_t,
+                updated_test,
             )
         self.db_conn.commit()
 
     def update_db_from_test_mapping(self, line_map, file_id):
-        # this should update the start and end lines of test functions with new line numbers calculated from changes
+        """Delete old test file mapping data and insert updated"""
         tests_to_update = []
         db_data = self.db_cursor.execute(
             """SELECT id,test_file_id,context,start,end FROM test_function
@@ -61,21 +70,25 @@ class DatabaseHelper:
             "DELETE FROM test_function WHERE test_file_id = ?", (file_id,)
         )
 
-        for t in tests_to_update:
-            start = t[3]
-            end = t[4]
+        for test in tests_to_update:
+            start = test[3]
+            end = test[4]
             if start in line_map:
                 start = line_map[start]
             if end in line_map:
                 end = line_map[end]
-            updated_t = (t[0], t[1], t[2], start, end)
+            updated_test = (test[0], test[1], test[2], start, end)
             self.db_cursor.execute(
-                "INSERT OR IGNORE INTO test_function (id,test_file_id,context,start,end) VALUES (?,?,?,?,?)",
-                updated_t,
+                """
+                INSERT OR IGNORE
+                INTO test_function (id,test_file_id,context,start,end)
+                VALUES (?,?,?,?,?)""",
+                updated_test,
             )
         self.db_conn.commit()
 
     def query_tests_srcfile(self, lines_to_query, file_id):
+        """Query tests for a source code file based on line numbers"""
         tests = []
         for line_id in lines_to_query:
             data = self.db_cursor.execute(
@@ -95,6 +108,7 @@ class DatabaseHelper:
         return tests
 
     def query_all_tests_srcfile(self, file_id):
+        """Query all tests for a source code file"""
         tests = []
         data = self.db_cursor.execute(
             """ SELECT DISTINCT context
@@ -109,12 +123,13 @@ class DatabaseHelper:
         return tests
 
     def query_tests_testfile(self, lines_to_query, file_id):
+        """Query tests for a test file based on line numbers"""
         tests = []
         for line_id in lines_to_query:
             data = self.db_cursor.execute(
                 """ SELECT DISTINCT context
                     FROM test_function
-                    WHERE test_file_id = ? 
+                    WHERE test_file_id = ?
                     AND start <= ?
                     AND end >= ?""",
                 (file_id, line_id, line_id),
@@ -125,6 +140,7 @@ class DatabaseHelper:
         return tests
 
     def get_testfiles_and_srcfiles(self):
+        """Query all source code and test files from database"""
         test_files = [
             (x[0], x[1])
             for x in self.db_cursor.execute("SELECT id,path FROM test_file").fetchall()
@@ -136,12 +152,14 @@ class DatabaseHelper:
         return test_files, src_files
 
     def get_test_suite_size(self):
+        """Query how many tests are in mapping database"""
         size = int(
             self.db_cursor.execute("SELECT count() FROM test_function").fetchone()[0]
         )
         return size
 
     def init_mapping_db(self):
+        """Initialize mapping database tables"""
         self.db_cursor.execute("DROP TABLE IF EXISTS test_map")
         self.db_cursor.execute("DROP TABLE IF EXISTS src_file")
         self.db_cursor.execute("DROP TABLE IF EXISTS test_file")
@@ -149,7 +167,11 @@ class DatabaseHelper:
         self.db_cursor.execute("DROP TABLE IF EXISTS new_tests")
         self.db_cursor.execute("DROP TABLE IF EXISTS last_update_hash")
         self.db_cursor.execute(
-            "CREATE TABLE test_map (file_id INTEGER, test_function_id INTEGER, line_id INTEGER, UNIQUE(file_id,test_function_id,line_id))"
+            """CREATE TABLE test_map (
+                file_id INTEGER,
+                test_function_id INTEGER,
+                line_id INTEGER,
+                UNIQUE(file_id,test_function_id,line_id))"""
         )
         self.db_cursor.execute(
             "CREATE TABLE src_file (id INTEGER PRIMARY KEY, path TEXT, UNIQUE (path))"
@@ -160,12 +182,12 @@ class DatabaseHelper:
         self.db_cursor.execute(
             """CREATE TABLE test_function (
                                 id INTEGER PRIMARY KEY,
-                                test_file_id INTEGER, 
-                                context TEXT, 
-                                start INTEGER, 
+                                test_file_id INTEGER,
+                                context TEXT,
+                                start INTEGER,
                                 end INTEGER,
                                 duration REAL,
-                                FOREIGN KEY (test_file_id) REFERENCES test_file(id), 
+                                FOREIGN KEY (test_file_id) REFERENCES test_file(id),
                                 UNIQUE (context))"""
         )
         self.db_cursor.execute("CREATE TABLE new_tests (context TEXT)")
@@ -173,14 +195,16 @@ class DatabaseHelper:
         self.db_conn.commit()
 
     def save_mapping_lines(self, src_id, test_function_id, lines):
-        for l in lines:
+        """Save a test_map row"""
+        for line in lines:
             self.db_cursor.execute(
                 "INSERT OR IGNORE INTO test_map (file_id,test_function_id,line_id) VALUES (?,?,?)",
-                (src_id, test_function_id, l),
+                (src_id, test_function_id, line),
             )
         self.db_conn.commit()
 
     def save_src_file(self, src_file):
+        """Save a source code row"""
         self.db_cursor.execute(
             "INSERT OR IGNORE INTO src_file (path) VALUES (?)", (src_file,)
         )
@@ -190,9 +214,8 @@ class DatabaseHelper:
         self.db_conn.commit()
         return src_id
 
-    def save_testfile_and_func(
-        self, testfile, testname, func_name, start, end, elapsed
-    ):
+    def save_testfile_and_func(self, testfile, testname, func_lines, elapsed):
+        """Save a test_file row and a test_function row"""
         self.db_cursor.execute(
             "INSERT OR IGNORE INTO test_file (path) VALUES (?)", (testfile,)
         )
@@ -200,8 +223,11 @@ class DatabaseHelper:
             "SELECT id FROM test_file WHERE path == ?", (testfile,)
         ).fetchone()[0]
         self.db_cursor.execute(
-            "INSERT OR IGNORE INTO test_function (test_file_id,context,start,end,duration) VALUES (?,?,?,?,?)",
-            (test_file_id, testname, start, end, elapsed),
+            """INSERT OR IGNORE
+            INTO test_function
+            (test_file_id,context,start,end,duration)
+            VALUES (?,?,?,?,?)""",
+            (test_file_id, testname, func_lines[0], func_lines[1], elapsed),
         )
         test_function_id = self.db_cursor.execute(
             "SELECT id FROM test_function WHERE context == ?", (testname,)
@@ -210,25 +236,28 @@ class DatabaseHelper:
         return test_file_id, test_function_id
 
     def get_test_duration(self, testname):
+        """Query run time duration for a test function"""
         data = self.db_cursor.execute(
             "SELECT duration FROM test_function WHERE context = ?", (testname,)
         ).fetchone()
-        if data == None or data == (None,):
+        if data in (None, (None,)):
             duration = 99999
         else:
             duration = data[0]
         return duration
 
     def read_newly_added_tests(self):
+        """Query new tests from database"""
         new_tests = set()
-        for t in [
+        for test in [
             x[0]
             for x in self.db_cursor.execute("SELECT context FROM new_tests").fetchall()
         ]:
-            new_tests.add(t)
+            new_tests.add(test)
         return new_tests
 
     def mapping_line_exists(self, file_id, line_id):
+        """Return whether a specific file has a specific line covered"""
         return bool(
             self.db_cursor.execute(
                 "SELECT EXISTS(SELECT file_id FROM test_map WHERE file_id = ? AND line_id = ?)",
@@ -240,15 +269,18 @@ class DatabaseHelper:
         )
 
     def save_last_update_hash(self, commithash):
+        """Save commit hash as last updated hash"""
         self.db_cursor.execute("DELETE FROM last_update_hash")
         self.db_cursor.execute("INSERT INTO last_update_hash VALUES (?)", (commithash,))
         self.db_conn.commit()
 
     def is_last_update_hash(self, commithash):
+        """Return whether a given commit hash is the last update hash"""
         db_hash = self.db_cursor.execute(
             "SELECT hash FROM last_update_hash"
         ).fetchone()[0]
         return db_hash == commithash
 
     def get_last_update_hash(self):
+        """Return latest update hash"""
         return self.db_cursor.execute("SELECT hash FROM last_update_hash").fetchone()[0]

--- a/tests_selector/utils/git.py
+++ b/tests_selector/utils/git.py
@@ -1,10 +1,11 @@
+"""This module contains code for git operations"""
 import re
 import subprocess
-
 from pydriller import GitRepository
 
 
 def get_git_repo(project_folder):
+    """Return a GitRepository"""
     if not project_folder:
         res = subprocess.check_output("git rev-parse --show-toplevel".split())
         project_folder = res.decode().strip()
@@ -12,11 +13,13 @@ def get_git_repo(project_folder):
 
 
 def changed_files_between_commits(commit1, commit2, project_folder=None):
+    """Get changed files between two commits"""
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("--name-only", commit1, commit2).split()
 
 
 def changed_files_current(project_folder=None):
+    """Get changed files in git working directory"""
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("--name-only").split()
 
@@ -24,11 +27,13 @@ def changed_files_current(project_folder=None):
 def file_diff_data_between_commits(
     filename, commithash1, commithash2, project_folder=None
 ):
+    """Get git diff for a file from changes between two commits"""
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", commithash1, commithash2, "--", filename)
 
 
 def file_diff_data_current(filename, project_folder=None):
+    """Get git diff for a file in git working directory"""
     repo = get_git_repo(project_folder)
     return repo.repo.git.diff("-U0", "--", filename)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist = py36,py37,py38,py39,py38-check-format
 deps = .[dev]
 commands =
         pylint -j 0 -s n setup.py tests_selector
-        mypy setup.py tests_selector
+        mypy setup.py tests_selector --ignore-missing-imports
         safety check
         pytest \
         --cov=tests_selector --cov-report html --cov-report term \


### PR DESCRIPTION
Fixed all `pylint` and `mypy` errors when running `tox`. Required some refactoring of functions but I tried to keep it to a minimal to not make this PR too big. Or is it too much already? Also does the commit message look as desired?  