### PR TITLE
fix: make the tool work in pytest-rts folder

### DIFF
--- a/pytest_rts/pytest/init_phase_plugin.py
+++ b/pytest_rts/pytest/init_phase_plugin.py
@@ -26,6 +26,7 @@ class InitPhasePlugin:
         self.database.init_mapping_db()
         self.head_hash = get_current_head_hash()
         self.database.save_last_update_hash(self.head_hash)
+        self.excluded_srcfiles = set()
 
     def pytest_collection_modifyitems(self, session, config, items):
         """Calculate function start and end line numbers from testfiles"""
@@ -53,11 +54,13 @@ class InitPhasePlugin:
             _, test_function_id = save_testfile_and_func_data(
                 item, elapsed, self.test_func_lines, self.database
             )
-            save_mapping_data(
-                test_function_id,
-                self.cov.get_data(),
-                self.testfiles,
-                self.database,
+            self.excluded_srcfiles.update(
+                save_mapping_data(
+                    test_function_id,
+                    self.cov.get_data(),
+                    self.testfiles,
+                    self.database,
+                )
             )
         else:
             yield

--- a/pytest_rts/pytest/update_phase_plugin.py
+++ b/pytest_rts/pytest/update_phase_plugin.py
@@ -26,6 +26,7 @@ class UpdatePhasePlugin:
         self.database = DatabaseHelper()
         self.database.init_conn()
         self.fill_times_dict()
+        self.excluded_srcfiles = set()
 
     def fill_times_dict(self):
         """Gets test durations from database used for test prioritization"""
@@ -84,11 +85,13 @@ class UpdatePhasePlugin:
             _, test_function_id = save_testfile_and_func_data(
                 item, elapsed, self.test_func_lines, self.database
             )
-            save_mapping_data(
-                test_function_id,
-                self.cov.get_data(),
-                self.testfiles,
-                self.database,
+            self.excluded_srcfiles.update(
+                save_mapping_data(
+                    test_function_id,
+                    self.cov.get_data(),
+                    self.testfiles,
+                    self.database,
+                )
             )
         else:
             yield

--- a/pytest_rts/tests/conftest.py
+++ b/pytest_rts/tests/conftest.py
@@ -10,7 +10,7 @@ from testhelper import TestHelper
 @pytest.fixture(scope="session", autouse=True)
 def temp_project_repo(tmpdir_factory):
     """Create a temporary Git repository and initialize the tool there"""
-    temp_folder = tmpdir_factory.mktemp("temp").join("testrepo")
+    temp_folder = tmpdir_factory.mktemp("temp").join("pytest-rts-testrepo")
     shutil.copytree("./pytest_rts/tests/helper_project", temp_folder)
     os.chdir(temp_folder)
 

--- a/pytest_rts/tests/helper_project/.coveragerc
+++ b/pytest_rts/tests/helper_project/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = tests/*
+source = .

--- a/pytest_rts/tests/test_db.py
+++ b/pytest_rts/tests/test_db.py
@@ -86,22 +86,3 @@ def test_update_db_from_test_mapping():
         new_func_linenumbers = new_func_line_dict[key]
         assert old_func_linenumbers[0] + shift == new_func_linenumbers[0]
         assert old_func_linenumbers[1] + shift == new_func_linenumbers[1]
-
-
-def test_tool_files_not_mapped():
-    conn = sqlite3.connect(DB_FILE_NAME)
-    tool_files_mapped = bool(
-        conn.execute(
-            """SELECT EXISTS(
-                SELECT * FROM src_file 
-                  WHERE 
-                    path LIKE '%/init_phase_plugin.py' 
-                    OR 
-                    path LIKE '%/update_phase_plugin.py'
-               )
-            """
-        ).fetchone()[0]
-    )
-    conn.close()
-
-    assert not tool_files_mapped

--- a/pytest_rts/tests/test_db.py
+++ b/pytest_rts/tests/test_db.py
@@ -86,3 +86,22 @@ def test_update_db_from_test_mapping():
         new_func_linenumbers = new_func_line_dict[key]
         assert old_func_linenumbers[0] + shift == new_func_linenumbers[0]
         assert old_func_linenumbers[1] + shift == new_func_linenumbers[1]
+
+
+def test_tool_files_not_mapped():
+    conn = sqlite3.connect(DB_FILE_NAME)
+    tool_files_mapped = bool(
+        conn.execute(
+            """SELECT EXISTS(
+                SELECT * FROM src_file 
+                  WHERE 
+                    path LIKE '%/init_phase_plugin.py' 
+                    OR 
+                    path LIKE '%/update_phase_plugin.py'
+               )
+            """
+        ).fetchone()[0]
+    )
+    conn.close()
+
+    assert not tool_files_mapped

--- a/pytest_rts/utils/common.py
+++ b/pytest_rts/utils/common.py
@@ -186,22 +186,19 @@ def save_testfile_and_func_data(item, elapsed_time, test_func_lines, db_helper):
 
 
 def save_mapping_data(test_function_id, cov_data, testfiles, db_helper):
-    """Save mapping database srcfile and lines covered"""
+    """Save mapping database srcfile and lines covered
+    and return the file paths that were excluded from source code file mapping
+    for logging
+    """
+    exluded_srcfiles = set()
     for filename in cov_data.measured_files():
         src_file = os.path.relpath(filename, os.getcwd())
-        conditions = [
-            "init_phase_plugin.py" in filename,
-            "update_phase_plugin.py" in filename,
-            ("/tmp/" in filename) and ("/tmp/" not in os.getcwd()),
-            "/.venv/" in filename,
-            src_file in testfiles,
-            src_file.endswith("conftest.py"),
-            not src_file.endswith(".py"),
-        ]
-        if any(conditions):
+        if src_file in testfiles:
+            exluded_srcfiles.add(src_file)
             continue
         src_id = db_helper.save_src_file(src_file)
         db_helper.save_mapping_lines(src_id, test_function_id, cov_data.lines(filename))
+    return exluded_srcfiles
 
 
 def calculate_func_lines(src_code):

--- a/pytest_rts/utils/common.py
+++ b/pytest_rts/utils/common.py
@@ -190,7 +190,8 @@ def save_mapping_data(test_function_id, cov_data, testfiles, db_helper):
     for filename in cov_data.measured_files():
         src_file = os.path.relpath(filename, os.getcwd())
         conditions = [
-            "pytest-rts" in filename,
+            "init_phase_plugin.py" in filename,
+            "update_phase_plugin.py" in filename,
             ("/tmp/" in filename) and ("/tmp/" not in os.getcwd()),
             "/.venv/" in filename,
             src_file in testfiles,


### PR DESCRIPTION
There was discussion in #62 that the `pytest-rts` condition in saving coverage data should be removed. I now changed it to only ignore the `init_phase_plugin.py` and `update_phase_plugin.py` which often get mapped as source files because they start the coverage collection. Would some other approach be better?  