### PR TITLE
feat: handle usage in non-git directory

### DIFF
--- a/pytest_rts/plugin.py
+++ b/pytest_rts/plugin.py
@@ -8,7 +8,11 @@ import pytest
 from pytest_rts.pytest.init_phase_plugin import InitPhasePlugin
 from pytest_rts.pytest.normal_phase_plugin import NormalPhasePlugin
 from pytest_rts.pytest.update_phase_plugin import UpdatePhasePlugin
-from pytest_rts.utils.git import get_current_head_hash
+from pytest_rts.utils.git import (
+    get_current_head_hash,
+    is_git_repo,
+    repo_has_commits,
+)
 from pytest_rts.utils.selection import (
     get_tests_and_data_committed,
     get_tests_and_data_current,
@@ -43,6 +47,18 @@ def pytest_configure(config):
     logging.basicConfig(format="%(message)s", level=logging.INFO)
 
     if not config.option.rts:
+        return
+
+    if not is_git_repo():
+        logger.info(
+            "Not a git repository! pytest-rts is disabled. Run git init before using pytest-rts."
+        )
+        return
+
+    if not repo_has_commits():
+        logger.info(
+            "No commits yet! pytest-rts is disabled. Create a git commit before using pytest-rts."
+        )
         return
 
     init_required = not os.path.isfile(DB_FILE_NAME)

--- a/pytest_rts/utils/git.py
+++ b/pytest_rts/utils/git.py
@@ -7,9 +7,36 @@ from pydriller import GitRepository
 def get_git_repo(project_folder):
     """Return a GitRepository"""
     if not project_folder:
-        res = subprocess.check_output("git rev-parse --show-toplevel".split())
+        res = subprocess.check_output(
+            "git rev-parse --show-toplevel".split(),
+            stderr=subprocess.DEVNULL,
+        )
         project_folder = res.decode().strip()
     return GitRepository(project_folder)
+
+
+def is_git_repo():
+    """Check if current directory or any parent directory is a git repo"""
+    try:
+        subprocess.check_output(
+            "git rev-parse --show-toplevel".split(),
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def repo_has_commits():
+    """Check if current repository has commits"""
+    try:
+        subprocess.check_output(
+            ["git", "log"],
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
 
 
 def changed_files_between_commits(commit1, commit2, project_folder=None):


### PR DESCRIPTION
Print out an error and run pytest normally if there is no git repository to be found or it doesn't have any commits. 

Fixes #79