### PR TITLE
chore: orm integration WIP

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 # Prevent helper project tests being collected as tests for pytest-rts
-norecursedirs = pytest_rts/tests/helper_project
+norecursedirs = pytest_rts/tests/helper_project pytest_rts/models

--- a/pytest_rts/connection.py
+++ b/pytest_rts/connection.py
@@ -1,0 +1,26 @@
+"""Code for mapping database connectivity"""
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from pytest_rts.models.base import Base
+
+DB_FILE_NAME = "mapping.db"
+
+
+class MappingConn:  # pylint: disable=too-few-public-methods
+    """Mapping database connection"""
+
+    _engine: Engine = None
+    _session: Session = None
+
+    @classmethod
+    def session(cls, connection_string=f"sqlite:///{DB_FILE_NAME}") -> Session:
+        """SQLAlchemy session"""
+        if not cls._engine:
+            cls._engine = create_engine(connection_string)
+            Base.metadata.create_all(cls._engine)
+        if not cls._session:
+            sessionmaker_instance = sessionmaker(bind=cls._engine)
+            cls._session = sessionmaker_instance()
+        return cls._session

--- a/pytest_rts/models/base.py
+++ b/pytest_rts/models/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()

--- a/pytest_rts/models/last_update_hash.py
+++ b/pytest_rts/models/last_update_hash.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String
+
+from pytest_rts.models.base import Base
+
+
+class LastUpdateHash(Base):
+    __tablename__ = "last_update_hash"
+    commithash = Column(String, primary_key=True)
+
+    def __init__(self, commithash):
+        self.commithash = commithash

--- a/pytest_rts/models/new_tests.py
+++ b/pytest_rts/models/new_tests.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String
+
+from pytest_rts.models.base import Base
+
+
+class NewTests(Base):
+    __tablename__ = "new_tests"
+    name = Column(String, primary_key=True)
+
+    def __init__(self, name):
+        self.name = name

--- a/pytest_rts/models/source_file.py
+++ b/pytest_rts/models/source_file.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, String, Integer, UniqueConstraint
+
+from pytest_rts.models.base import Base
+
+
+class SourceFile(Base):
+    __tablename__ = "src_file"
+    __table_args__ = (UniqueConstraint("path", sqlite_on_conflict="IGNORE"),)
+
+    id = Column(Integer, primary_key=True)
+    path = Column(String)
+
+    def __init__(self, path):
+        self.path = path

--- a/pytest_rts/models/test_file.py
+++ b/pytest_rts/models/test_file.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, String, Integer, UniqueConstraint
+
+from pytest_rts.models.base import Base
+
+
+class TestFile(Base):
+    __tablename__ = "test_file"
+    __table_args__ = (UniqueConstraint("path", sqlite_on_conflict="IGNORE"),)
+
+    id = Column(Integer, primary_key=True)
+    path = Column(String)
+
+    def __init__(self, path):
+        self.path = path

--- a/pytest_rts/models/test_function.py
+++ b/pytest_rts/models/test_function.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, ForeignKey, Float, String, Integer, UniqueConstraint
+
+from pytest_rts.models.base import Base
+
+
+class TestFunction(Base):
+    __tablename__ = "test_function"
+    __table_args__ = (UniqueConstraint("name", sqlite_on_conflict="IGNORE"),)
+
+    id = Column(Integer, primary_key=True)
+    test_file_id = Column(Integer, ForeignKey("test_file.id"))
+    name = Column(String)
+    start = Column(Integer)
+    end = Column(Integer)
+    duration = Column(Float)
+
+    def __init__(self, test_file_id, name, start, end, duration):
+        self.test_file_id = test_file_id
+        self.name = name
+        self.start = start
+        self.end = end
+        self.duration = duration

--- a/pytest_rts/models/test_map.py
+++ b/pytest_rts/models/test_map.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, ForeignKey, Integer, UniqueConstraint
+
+from pytest_rts.models.base import Base
+
+
+class TestMap(Base):
+    __tablename__ = "test_map"
+    __table_args__ = (
+        UniqueConstraint(
+            "file_id", "test_function_id", "line_number", sqlite_on_conflict="IGNORE"
+        ),
+    )
+
+    file_id = Column(Integer, ForeignKey("src_file.id"), primary_key=True)
+    test_function_id = Column(Integer, ForeignKey("test_function.id"), primary_key=True)
+    line_number = Column(Integer, primary_key=True)
+
+    def __init__(self, file_id, test_function_id, line_number):
+        self.file_id = file_id
+        self.test_function_id = test_function_id
+        self.line_number = line_number

--- a/pytest_rts/pytest/collect_plugin.py
+++ b/pytest_rts/pytest/collect_plugin.py
@@ -1,7 +1,6 @@
 """This module contains code for collecting newly added tests"""
 # pylint: disable=too-few-public-methods
-import sqlite3
-from pytest_rts.plugin import DB_FILE_NAME
+from pytest_rts.connection import MappingConn
 from pytest_rts.utils.testgetter import TestGetter
 
 
@@ -11,8 +10,7 @@ class CollectPlugin:
     def __init__(self):
         """Query existing test functions from database before collection"""
         self.collected = set()
-        self.conn = sqlite3.connect(DB_FILE_NAME)
-        self.testgetter = TestGetter(self.conn)
+        self.testgetter = TestGetter(MappingConn.session())
         self.existing_tests = self.testgetter.existing_tests
         self.testgetter.delete_newly_added_tests()
 
@@ -23,5 +21,5 @@ class CollectPlugin:
             if item.nodeid not in self.existing_tests:
                 self.collected.add(item.nodeid)
         self.testgetter.set_newly_added_tests(self.collected)
-        self.conn.commit()
-        self.conn.close()
+        MappingConn.session().commit()
+        MappingConn.session().close()

--- a/pytest_rts/pytest/init_phase_plugin.py
+++ b/pytest_rts/pytest/init_phase_plugin.py
@@ -22,7 +22,6 @@ class InitPhasePlugin:
         self.test_func_lines = None
 
         self.mappinghelper = mappinghelper
-        self.mappinghelper.init_mapping()
         self.mappinghelper.set_last_update_hash(get_current_head_hash())
 
     def pytest_collection_modifyitems(self, session, config, items):

--- a/pytest_rts/pytest/update_phase_plugin.py
+++ b/pytest_rts/pytest/update_phase_plugin.py
@@ -34,7 +34,7 @@ class UpdatePhasePlugin:
         self.mappinghelper = mappinghelper
         self.testgetter = testgetter
 
-        self.testfiles = {testfile[1] for testfile in self.mappinghelper.testfiles}
+        self.testfiles = {testfile.path for testfile in self.mappinghelper.testfiles}
         self.test_func_lines = None
         self.test_func_times = self.testgetter.test_function_runtimes
 

--- a/pytest_rts/tests/conftest.py
+++ b/pytest_rts/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import shutil
 import pytest
-from pytest_rts.plugin import DB_FILE_NAME
+from pytest_rts.connection import DB_FILE_NAME
 from testhelper import TestHelper
 
 

--- a/pytest_rts/tests/session_wrapper.py
+++ b/pytest_rts/tests/session_wrapper.py
@@ -1,0 +1,15 @@
+from functools import wraps
+
+from pytest_rts.connection import MappingConn
+
+
+def with_session(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        session = MappingConn.session()
+        try:
+            return func(*args, **kwargs, session=session)
+        finally:
+            session.close()
+
+    return wrapper

--- a/pytest_rts/tests/test_e2e.py
+++ b/pytest_rts/tests/test_e2e.py
@@ -8,7 +8,7 @@ def test_full_integration(helper):
     helper.change_file("changes/car/add_new_method.txt", "src/car.py")
 
     # Get changed src file id
-    src_file_id = helper.get_mapping_id_from_filename("src/car.py", is_srcfile=True)
+    src_file_id = helper.get_mapping_id_for_srcfile("src/car.py")
 
     # Get working directory test_set like in pytest_rts script
     workdir_test_set = helper.get_tests_from_tool_current()
@@ -79,7 +79,7 @@ def test_db_updating_only_once(helper):
     change = "changes/car/shift_2_forward.txt"
     expected_lines = [6, 7, 8, 11, 14]
 
-    src_file_id = helper.get_mapping_id_from_filename(filename, is_srcfile=True)
+    src_file_id = helper.get_mapping_id_for_srcfile(filename)
     old_lines = helper.get_mapping_lines_for_srcfile(src_file_id)
 
     # Change src file

--- a/pytest_rts/tests/testhelper.py
+++ b/pytest_rts/tests/testhelper.py
@@ -1,71 +1,64 @@
-import sqlite3
 import subprocess
-from pytest_rts.plugin import DB_FILE_NAME
+
 from pytest_rts.utils.common import run_new_test_collection
+from pytest_rts.utils.mappinghelper import MappingHelper
 from pytest_rts.utils.selection import (
     get_tests_and_data_committed,
     get_tests_and_data_current,
 )
-from pytest_rts.utils.mappinghelper import MappingHelper
+from pytest_rts.tests.session_wrapper import with_session
 from pytest_rts.utils.testgetter import TestGetter
+from pytest_rts.models.test_map import TestMap
+from pytest_rts.models.test_function import TestFunction
 
 
 class TestHelper:
-    def get_mapping_id_from_filename(self, filename, is_srcfile):
-        if is_srcfile:
-            sql = "SELECT id FROM src_file WHERE path = ?"
-        else:
-            sql = "SELECT id from test_file WHERE path = ?"
+    @with_session
+    def get_mapping_id_for_srcfile(self, path, session=None):
+        return MappingHelper(session)._get_srcfile(path)
 
-        conn = sqlite3.connect(DB_FILE_NAME)
-        file_id = conn.execute(sql, (filename,)).fetchone()[0]
-        conn.close()
-        return file_id
+    @with_session
+    def get_mapping_id_for_test(self, path, session=None):
+        return MappingHelper(session)._get_testfile(path)
 
-    def get_mapping_lines_for_srcfile(self, src_file_id):
-        conn = sqlite3.connect(DB_FILE_NAME)
-        lines = [
-            x[0]
-            for x in conn.execute(
-                "SELECT line_id FROM test_map WHERE file_id = ?", (src_file_id,)
-            ).fetchall()
+    @with_session
+    def get_mapping_lines_for_srcfile(self, src_file_id, session=None):
+        return [
+            line_map.line_number
+            for line_map in session.query(TestMap.line_number).filter(
+                TestMap.file_id == src_file_id
+            )
         ]
-        conn.close()
-        return lines
 
-    def get_tests_from_tool_current(self):
-        conn = sqlite3.connect(DB_FILE_NAME)
-        mappinghelper = MappingHelper(conn)
-        testgetter = TestGetter(conn)
+    @with_session
+    def get_tests_from_tool_current(self, session=None):
+        mappinghelper = MappingHelper(session)
+        testgetter = TestGetter(session)
         change_data = get_tests_and_data_current(mappinghelper, testgetter)
-        conn.close()
         return change_data.test_set
 
-    def get_tests_from_tool_committed(self):
-        conn = sqlite3.connect(DB_FILE_NAME)
-        mappinghelper = MappingHelper(conn)
-        testgetter = TestGetter(conn)
+    @with_session
+    def get_tests_from_tool_committed(self, session=None):
+        mappinghelper = MappingHelper(session)
+        testgetter = TestGetter(session)
         change_data = get_tests_and_data_committed(
             mappinghelper,
             testgetter,
         )
-        conn.close()
         return change_data.test_set
 
-    def get_newly_added_tests_from_tool(self):
+    @with_session
+    def get_newly_added_tests_from_tool(self, session=None):
         run_new_test_collection()
-        conn = sqlite3.connect(DB_FILE_NAME)
-        testgetter = TestGetter(conn)
+        testgetter = TestGetter(session)
         new_tests = testgetter.newly_added_tests
-        conn.close()
         return new_tests
 
-    def new_test_exists_in_mapping_db(self, testname):
-        conn = sqlite3.connect(DB_FILE_NAME)
-        sql = "SELECT EXISTS(SELECT id FROM test_function WHERE context = ?)"
-        exists = bool(conn.execute(sql, (testname,)).fetchone()[0])
-        conn.close()
-        return exists
+    @with_session
+    def new_test_exists_in_mapping_db(self, testname, session=None):
+        return bool(
+            session.query(TestFunction).filter(TestFunction.name == testname).first()
+        )
 
     def change_file(self, change_path, file_path):
         subprocess.run(

--- a/pytest_rts/utils/selection.py
+++ b/pytest_rts/utils/selection.py
@@ -1,12 +1,9 @@
 """This module contains code for the test selection functionality of the RTS tool"""
-from typing import Dict, List, NamedTuple, Set, Tuple
+from typing import Dict, List, NamedTuple, Set
 from pytest_rts.utils.common import (
     file_diff_dict_between_commits,
     file_diff_dict_current,
     run_new_test_collection,
-    split_changes,
-    tests_from_changed_srcfiles,
-    tests_from_changed_testfiles,
 )
 from pytest_rts.utils.git import (
     changed_files_current,
@@ -15,7 +12,8 @@ from pytest_rts.utils.git import (
 )
 from pytest_rts.utils.mappinghelper import MappingHelper
 from pytest_rts.utils.testgetter import TestGetter
-
+from pytest_rts.models.source_file import SourceFile
+from pytest_rts.models.test_file import TestFile
 
 UpdateData = NamedTuple(
     "UpdateData",
@@ -65,8 +63,8 @@ TestsFromChangesInput = NamedTuple(
     [
         ("test_file_diffs", Dict[int, str]),
         ("src_file_diffs", Dict[int, str]),
-        ("testfiles", List[Tuple[int, str]]),
-        ("srcfiles", List[Tuple[int, str]]),
+        ("testfiles", List[TestFile]),
+        ("srcfiles", List[SourceFile]),
         ("mappinghelper", MappingHelper),
         ("testgetter", TestGetter),
     ],
@@ -80,21 +78,19 @@ def get_tests_from_changes(tests_from_changes_input) -> TestsAndDataFromChanges:
         changed_lines_src,
         new_line_map_src,
         files_to_warn,
-    ) = tests_from_changed_srcfiles(
+    ) = tests_from_changes_input.testgetter.tests_from_changed_srcfiles(
         tests_from_changes_input.src_file_diffs,
         tests_from_changes_input.srcfiles,
         tests_from_changes_input.mappinghelper,
-        tests_from_changes_input.testgetter,
     )
 
     (
         test_test_set,
         changed_lines_test,
         new_line_map_test,
-    ) = tests_from_changed_testfiles(
+    ) = tests_from_changes_input.testgetter.tests_from_changed_testfiles(
         tests_from_changes_input.test_file_diffs,
         tests_from_changes_input.testfiles,
-        tests_from_changes_input.testgetter,
     )
 
     test_set = test_test_set.union(src_test_set)
@@ -114,7 +110,7 @@ def get_tests_from_changes(tests_from_changes_input) -> TestsAndDataFromChanges:
 def get_tests_and_data_current(mappinghelper, testgetter) -> TestsAndDataCurrent:
     """Returns the test set from working directory changes and data for printing statistics"""
     changed_files = changed_files_current()
-    changed_test_files, changed_src_files = split_changes(changed_files, mappinghelper)
+    changed_test_files, changed_src_files = mappinghelper.split_changes(changed_files)
 
     src_file_diffs = file_diff_dict_current(changed_src_files)
     test_file_diffs = file_diff_dict_current(changed_test_files)
@@ -145,7 +141,7 @@ def get_tests_and_data_committed(mappinghelper, testgetter) -> TestsAndDataCommi
     previous_hash = mappinghelper.last_update_hash
 
     changed_files = changed_files_between_commits(previous_hash, current_hash)
-    changed_test_files, changed_src_files = split_changes(changed_files, mappinghelper)
+    changed_test_files, changed_src_files = mappinghelper.split_changes(changed_files)
 
     src_file_diffs = file_diff_dict_between_commits(
         changed_src_files, previous_hash, current_hash

--- a/pytest_rts/utils/testgetter.py
+++ b/pytest_rts/utils/testgetter.py
@@ -1,82 +1,127 @@
 """Module for TestGetter class"""
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
+
+from pytest_rts.models.test_function import TestFunction
+from pytest_rts.models.test_map import TestMap
+from pytest_rts.models.new_tests import NewTests
+from pytest_rts.utils.common import line_mapping
+from pytest_rts.utils.git import get_test_lines_and_update_lines
 
 
 class TestGetter:
     """Class to query tests and information from the mapping database"""
 
-    def __init__(self, connection):
+    def __init__(self, session):
         """Set the connection"""
-        self.connection = connection
+        self.session = session
 
     @property
     def existing_tests(self) -> Set[str]:
         """Test function names that exist in the mapping database"""
         return {
-            x[0]
-            for x in self.connection.execute(
-                "SELECT context FROM test_function"
-            ).fetchall()
+            testfunction.name for testfunction in self.session.query(TestFunction.name)
         }
 
     @property
     def newly_added_tests(self) -> Set[str]:
         """New tests collected but not yet mapped"""
-        return {
-            x[0]
-            for x in self.connection.execute("SELECT context FROM new_tests").fetchall()
-        }
+        return {testfunction.name for testfunction in self.session.query(NewTests.name)}
 
     @property
     def test_function_runtimes(self) -> Dict[str, float]:
         """Dictionary with saved runtimes for each test function"""
         return {
-            x[0]: x[1]
-            for x in self.connection.execute(
-                "SELECT context, duration FROM test_function"
-            ).fetchall()
+            row.name: row.duration
+            for row in self.session.query(TestFunction.name, TestFunction.duration)
         }
 
-    def get_tests_from_srcfiles(self, changed_lines, file_id) -> List[str]:
+    def _get_tests_from_srcfiles(self, changed_lines, file_id) -> List[str]:
         """Query tests from source code files based on changed line numbers"""
         return [
-            line[0]
-            for line in self.connection.execute(
-                f""" SELECT DISTINCT context
-                    FROM test_function
-                    JOIN test_map ON test_function.id == test_map.test_function_id
-                    WHERE test_map.line_id IN ({','.join(['?']*len(changed_lines))})
-                    AND test_map.file_id = ?  """,
-                changed_lines + [file_id],
-            )
+            testfunction.name
+            for testfunction in self.session.query(TestFunction.name)
+            .join(TestMap)
+            .filter(TestMap.line_number.in_(changed_lines), TestMap.file_id == file_id)
         ]
 
-    def get_tests_from_testfiles(self, changed_lines, file_id) -> List[str]:
+    def _get_tests_from_testfiles(self, changed_lines, file_id) -> List[str]:
         """Query tests from changed test code files based on changed line numbers"""
         tests = []
-        for line_number in changed_lines:
+        for line in changed_lines:
             tests.extend(
                 [
-                    line[0]
-                    for line in self.connection.execute(
-                        """ SELECT DISTINCT context
-                            FROM test_function
-                            WHERE test_file_id = ?
-                            AND start <= ?
-                            AND end >= ?""",
-                        (file_id, line_number, line_number),
+                    testfunction.name
+                    for testfunction in self.session.query(TestFunction.name)
+                    .distinct(TestFunction.name)
+                    .filter(
+                        TestFunction.test_file_id == file_id,
+                        TestFunction.start <= line,
+                        TestFunction.end >= line,
                     )
                 ]
             )
-
         return tests
+
+    def tests_from_changed_testfiles(
+        self, diff_dict, files
+    ) -> Tuple[Set[str], Dict[int, List[int]], Dict[int, Dict[int, int]]]:
+        """Calculate test set and update data from changes to a testfile"""
+        test_set: Set[str] = set()
+        changed_lines_map: Dict[int, List[int]] = {}
+        new_line_map: Dict[int, Dict[int, int]] = {}
+        for testfile in files:
+            changed_lines, updates_to_lines, _ = get_test_lines_and_update_lines(
+                diff_dict[testfile.id]
+            )
+
+            changed_lines_map[testfile.id] = changed_lines
+            new_line_map[testfile.id] = line_mapping(updates_to_lines, testfile.path)
+
+            test_set.update(self._get_tests_from_testfiles(changed_lines, testfile.id))
+
+        return test_set, changed_lines_map, new_line_map
+
+    def tests_from_changed_srcfiles(
+        self, diff_dict, files, mappinghelper
+    ) -> Tuple[Set[str], Dict[int, List[int]], Dict[int, Dict[int, int]], List[str]]:
+        """
+        Calculate test set,
+        update data
+        and warning for untested new lines from changes to a source code file
+        """
+
+        test_set: Set[str] = set()
+        changed_lines_map: Dict[int, List[int]] = {}
+        new_line_map: Dict[int, Dict[int, int]] = {}
+        files_to_warn: List[str] = []
+        for srcfile in files:
+            (
+                changed_lines,
+                updates_to_lines,
+                new_lines,
+            ) = get_test_lines_and_update_lines(diff_dict[srcfile.id])
+
+            changed_lines_map[srcfile.id] = changed_lines
+            new_line_map[srcfile.id] = line_mapping(updates_to_lines, srcfile.path)
+
+            if not all(
+                [
+                    mappinghelper.line_exists(srcfile.id, line_number)
+                    for line_number in new_lines
+                ]
+            ):
+                files_to_warn.append(srcfile.path)
+
+            test_set.update(self._get_tests_from_srcfiles(changed_lines, srcfile.id))
+
+        return test_set, changed_lines_map, new_line_map, files_to_warn
 
     def set_newly_added_tests(self, test_set):
         """Store the newly added and collected tests"""
-        self.connection.executemany(
-            "INSERT INTO new_tests (context) VALUES (?)", [(test,) for test in test_set]
+        self.session.bulk_save_objects(
+            [NewTests(name=testname) for testname in test_set]
         )
 
     def delete_newly_added_tests(self):
         """Clear the new tests table"""
-        self.connection.execute("DELETE FROM new_tests")
+        self.session.query(NewTests).delete()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,13 @@ setup(
             f"{NAME_DASHED}={NAME}.plugin",
         ],
     },
-    install_requires=["pydriller", "coverage", "pytest"],
+    install_requires=[
+        "pydriller",
+        "coverage",
+        "pytest",
+        "sqlalchemy",
+        "sqlalchemy_utils",
+    ],
     extras_require={"dev": DEV_REQUIRE},
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Hey @alexey-vyskubov 

I did a mistake in our profiling session and we were actually running the `master` version of pytest-rts when we were seeing similar results between using `SQLAlchemy` and the current `SQLite3` version. This version here seems to run 2x slower than `master` but the logic seems identical to `master`. I tried to improve performance with various tweaks to `session.flush` ordering and relationship management (orm objects vs id's) but I didn't really progress anywhere. Also, the changing database size between runs applies to the `master` version as well. I'll have to investigate why this happens.

With this version, the run of `pandas/tests/arithmetic` (as in CHANGELOG) takes nearly 12 minutes, instead of the 5.5 minutes. Also here's profiling between `master` and this version for "flask"

this branch:
```
         34149048 function calls (33673277 primitive calls) in 33.472 seconds

   Ordered by: internal time
   List reduced from 10699 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    19451    1.154    0.000    2.804    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/inspect.py:726(getmodule)
2202603/2202505    0.788    0.000    0.824    0.000 {built-in method builtins.hasattr}
4454118/4439711    0.600    0.000    0.651    0.000 {built-in method builtins.isinstance}
    27762    0.532    0.000    1.291    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py:771(_init_compiled)
   192382    0.464    0.000    0.464    0.000 {built-in method posix.lstat}
   108906    0.448    0.000    0.658    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:334(normpath)
   245828    0.424    0.000    0.653    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:71(join)
  2058213    0.403    0.000    0.549    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/inspect.py:63(ismodule)
    36758    0.381    0.000    0.381    0.000 {method 'execute' of 'sqlite3.Connection' objects}
   167350    0.378    0.000    0.505    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py:478(_collect_insert_commands)
     3262    0.307    0.000    0.307    0.000 {method 'executemany' of 'sqlite3.Cursor' objects}
     5582    0.300    0.000    0.300    0.000 {method 'executemany' of 'sqlite3.Connection' objects}
 19204/53    0.294    0.000   33.479    0.632 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/pluggy/callers.py:157(_multicall)
    24521    0.270    0.000    0.270    0.000 {method 'execute' of 'sqlite3.Cursor' objects}
  2234130    0.270    0.000    0.270    0.000 {method 'get' of 'dict' objects}
    35723    0.263    0.000    0.576    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/sql/elements.py:965(__init__)
    75556    0.263    0.000    0.263    0.000 {built-in method posix.stat}
   156531    0.260    0.000    0.260    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/sql/compiler.py:709(construct_params)
    27780    0.256    0.000    2.957    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py:1186(_execute_context)
28149/28146    0.255    0.000    1.385    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:396(_joinrealpath)
    22719    0.253    0.000    3.343    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py:1039(_emit_insert_statements)
        9    0.227    0.025    0.227    0.025 {built-in method posix.waitpid}
      540    0.225    0.000    0.225    0.000 {method 'executescript' of 'sqlite3.Connection' objects}
    11899    0.211    0.000    4.576    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/sqlalchemy/orm/session.py:2559(_flush)
     5768    0.207    0.000    0.207    0.000 {built-in method builtins.compile}

```

master:
```
         19609466 function calls (19378647 primitive calls) in 14.235 seconds

   Ordered by: internal time
   List reduced from 8071 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    19451    0.768    0.000    1.896    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/inspect.py:726(getmodule)
    16401    0.548    0.000    0.548    0.000 {method 'executemany' of 'sqlite3.Connection' objects}
1588066/1588058    0.521    0.000    0.550    0.000 {built-in method builtins.hasattr}
   189814    0.410    0.000    0.410    0.000 {built-in method posix.lstat}
   108435    0.387    0.000    0.568    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:334(normpath)
    60570    0.382    0.000    0.382    0.000 {method 'execute' of 'sqlite3.Connection' objects}
   242664    0.353    0.000    0.551    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:71(join)
3268012/3253587    0.306    0.000    0.316    0.000 {built-in method builtins.isinstance}
  1543336    0.277    0.000    0.375    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/inspect.py:63(ismodule)
 19204/53    0.264    0.000   14.114    0.266 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/pluggy/callers.py:157(_multicall)
    73758    0.229    0.000    0.229    0.000 {built-in method posix.stat}
     5780    0.227    0.000    0.227    0.000 {built-in method builtins.compile}
        9    0.223    0.025    0.223    0.025 {built-in method posix.waitpid}
27914/27911    0.218    0.000    1.202    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:396(_joinrealpath)
      540    0.205    0.000    0.205    0.000 {method 'executescript' of 'sqlite3.Connection' objects}
      410    0.204    0.000    0.204    0.000 /home/eero/Desktop/flask/src/flask/app.py:1980(try_trigger_before_first_request_functions)
126016/122040    0.161    0.000    3.749    0.000 {built-in method builtins.next}
    10819    0.159    0.000    0.340    0.000 /home/eero/Desktop/pytest-rts/.venv/lib/python3.8/site-packages/coverage/sqldata.py:879(arcs)
  1508602    0.140    0.000    0.141    0.000 {method 'get' of 'dict' objects}
   639957    0.125    0.000    0.125    0.000 {method 'startswith' of 'str' objects}
   126203    0.117    0.000    0.237    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/ast.py:214(iter_child_nodes)
      540    0.110    0.000    1.684    0.003 /home/eero/Desktop/pytest-rts/pytest_rts/utils/mappinghelper.py:238(save_testrun_data)
    18371    0.108    0.000    1.988    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/inspect.py:772(findsource)
    23267    0.107    0.000    0.646    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:449(relpath)
   189814    0.107    0.000    0.538    0.000 /home/eero/.pyenv/versions/3.8.5/lib/python3.8/posixpath.py:164(islink)

```
