### PR TITLE
feat: rts from committed changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ relative_files = True
 
 As a result only tests related to changes in working directory will be executed.
 
-#### Tests from committed changes
+#### Tests from working directory + committed changes 
 
 1. Install `pytest-rts` with `pip install pytest-rts`
 2. Create a branch `git checkout -b feat/new-feature`
 3. Make changes in your code and commit them
 4. Run the tool with `pytest --rts --rts-coverage-db=[path to database] --rts-from-commit=[database initialization commithash]`
 
-As a result only tests related to committed changes will be executed. The tool compares the given commithash to the current Git HEAD.
+The current git working directory copy will be compared to the given commithash. Tests for changes in commits and in the working directory will be executed.
 
 ### Usage in CI
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,23 @@ relative_files = True
 
 ### Local usage
 
+#### Tests from changes in Git working directory
+
 1. Install `pytest-rts` with `pip install pytest-rts`
 2. Create a branch `git checkout -b feat/new-feature`
 3. Make changes in your code
 4. Run the tool with `pytest --rts --rts-coverage-db=[path to database]`
 
-As a result only tests related to changes in working directory and branch will be executed.
+As a result only tests related to changes in working directory will be executed.
+
+#### Tests from committed changes
+
+1. Install `pytest-rts` with `pip install pytest-rts`
+2. Create a branch `git checkout -b feat/new-feature`
+3. Make changes in your code and commit them
+4. Run the tool with `pytest --rts --rts-coverage-db=[path to database] --rts-from-commit=[database initialization commithash]`
+
+As a result only tests related to committed changes will be executed. The tool compares the given commithash to the current Git HEAD.
 
 ### Usage in CI
 
@@ -40,7 +51,7 @@ As a result only tests related to changes in working directory and branch will b
   * or, if the database size is big, upload it to some storage
 * In pull requests:
   * make sure you have coverage database from the main branch located next to the code
-  * run `pytest --rts --rts-coverage-db=[path to database]`
+  * run `pytest --rts --rts-coverage-db=[path to database] --rts-from-commit=[database initialization commithash]`
 
 ## <a name="troubleshooting"></a> Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ relative_files = True
 
 As a result only tests related to changes in working directory will be executed.
 
-#### Tests from working directory + committed changes 
+#### Tests from changes in Git working directory + committed changes
 
 1. Install `pytest-rts` with `pip install pytest-rts`
 2. Create a branch `git checkout -b feat/new-feature`

--- a/pytest_rts/plugin.py
+++ b/pytest_rts/plugin.py
@@ -8,10 +8,9 @@ from _pytest.config.argparsing import Parser
 from pytest_rts.pytest.runner_plugin import RunnerPlugin
 from pytest_rts.utils.common import (
     get_existing_tests,
-    get_tests_current,
-    get_tests_committed,
+    get_tests_from_changes,
 )
-from pytest_rts.utils.git import commit_exists, is_git_repo
+from pytest_rts.utils.git import is_git_repo
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -46,17 +45,8 @@ def pytest_configure(config: Config) -> None:
     if not os.path.exists(config.option.rts_coverage_db):
         pytest.exit("pytest-rts: Provided coverage file does not exist", 2)
 
-    if not config.option.rts_from_commit:
-        existing_tests = get_existing_tests(config.option.rts_coverage_db)
-        workdir_tests = get_tests_current(config.option.rts_coverage_db)
-        config.pluginmanager.register(RunnerPlugin(existing_tests, workdir_tests))
-        return
-
-    if not commit_exists(config.option.rts_from_commit):
-        pytest.exit("pytest-rts: Given commithash does not exist", 2)
-
     existing_tests = get_existing_tests(config.option.rts_coverage_db)
-    committed_tests = get_tests_committed(
+    tests_from_changes = get_tests_from_changes(
         config.option.rts_from_commit, config.option.rts_coverage_db
     )
-    config.pluginmanager.register(RunnerPlugin(existing_tests, committed_tests))
+    config.pluginmanager.register(RunnerPlugin(existing_tests, tests_from_changes))

--- a/pytest_rts/plugin.py
+++ b/pytest_rts/plugin.py
@@ -1,4 +1,5 @@
 """Code for pytest-rts plugin logic"""
+import logging
 import os
 
 import pytest
@@ -44,6 +45,8 @@ def pytest_configure(config: Config) -> None:
 
     if not os.path.exists(config.option.rts_coverage_db):
         pytest.exit("pytest-rts: Provided coverage file does not exist", 2)
+
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
 
     existing_tests = get_existing_tests(config.option.rts_coverage_db)
     tests_from_changes = get_tests_from_changes(

--- a/pytest_rts/tests/helper_project/.gitignore
+++ b/pytest_rts/tests/helper_project/.gitignore
@@ -1,3 +1,6 @@
 .coverage
-rts-coverage.1234
+rts-coverage.db
 *__pycache__*
+runpytest-*
+stderr
+stdout

--- a/pytest_rts/tests/test_e2e.py
+++ b/pytest_rts/tests/test_e2e.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 import pytest
 from _pytest.pytester import Testdir
 
-from pytest_rts.utils.git import get_current_head_hash, get_git_repo
+from pytest_rts.utils.git import get_git_repo
 
 COV_FILE = "rts-coverage.db"
 
@@ -84,7 +84,8 @@ def get_testrepo_commithash(tmp_testdir_path: str) -> str:
     """Helper function to return the current Git HEAD in the testrepo"""
     if os.getcwd() != tmp_testdir_path:
         return ""
-    return get_current_head_hash(get_git_repo())
+    repo = get_git_repo()
+    return repo.repo.head.object.hexsha
 
 
 def squash_commits(tmp_testdir_path: str, num_to_squash: int) -> None:

--- a/pytest_rts/utils/common.py
+++ b/pytest_rts/utils/common.py
@@ -49,17 +49,12 @@ def get_tests_from_changes(
     commithash_to_compare: str, coverage_file_path: str
 ) -> Set[str]:
     """Returns the test set from Git changes.
-    If the provided commithash does not exist in the repo,
-    then only changes in the git working directory are considered.
-    Otherwise the commithash is compared to the current working copy.
+    The given commithash is compared to the current working copy
+    to extract Git diffs, if the provided commithash exists in the repo.
+    Otherwise only changes in the git working directory are considered.
     """
     repo = get_git_repo()
-    if not commit_exists(commithash_to_compare, repo):
-        file_diffs = {
-            file_path: get_file_diff_data_workdir(repo, file_path)
-            for file_path in get_changed_files_workdir(repo)
-        }
-    else:
+    if commit_exists(commithash_to_compare, repo):
         file_diffs = {
             file_path: get_file_diff_data_committed_and_workdir(
                 repo, file_path, commithash_to_compare
@@ -67,6 +62,11 @@ def get_tests_from_changes(
             for file_path in get_changed_files_committed_and_workdir(
                 repo, commithash_to_compare
             )
+        }
+    else:
+        file_diffs = {
+            file_path: get_file_diff_data_workdir(repo, file_path)
+            for file_path in get_changed_files_workdir(repo)
         }
     coverage_data = CoverageData(coverage_file_path)
     coverage_data.read()

--- a/pytest_rts/utils/common.py
+++ b/pytest_rts/utils/common.py
@@ -8,7 +8,10 @@ from pytest_rts.utils.git import (
     get_git_repo,
     get_changed_lines,
     get_changed_files_current,
-    get_file_diff_dict_current,
+    get_changed_files_between_commits,
+    get_current_head_hash,
+    get_file_diff_data_current,
+    get_file_diff_data_between_commits,
 )
 
 
@@ -73,7 +76,28 @@ def get_tests_current(coverage_file_path: str) -> Set[str]:
     """Returns the test set from working directory changes"""
     repo = get_git_repo()
     changed_files = get_changed_files_current(repo)
-    file_diffs = get_file_diff_dict_current(repo, changed_files)
+    file_diffs = {
+        file_path: get_file_diff_data_current(repo, file_path)
+        for file_path in changed_files
+    }
+    return get_tests_from_changes(file_diffs, coverage_file_path)
+
+
+def get_tests_committed(
+    commithash_to_compare: str, coverage_file_path: str
+) -> Set[str]:
+    """Returns the test set from committed changes"""
+    repo = get_git_repo()
+    current_hash = get_current_head_hash(repo)
+    changed_files = get_changed_files_between_commits(
+        repo, commithash_to_compare, current_hash
+    )
+    file_diffs = {
+        file_path: get_file_diff_data_between_commits(
+            repo, file_path, commithash_to_compare, current_hash
+        )
+        for file_path in changed_files
+    }
     return get_tests_from_changes(file_diffs, coverage_file_path)
 
 

--- a/pytest_rts/utils/common.py
+++ b/pytest_rts/utils/common.py
@@ -9,7 +9,6 @@ from pytest_rts.utils.git import (
     get_changed_lines,
     get_changed_files_current,
     get_changed_files_between_commits,
-    get_current_head_hash,
     get_file_diff_data_current,
     get_file_diff_data_between_commits,
 )
@@ -88,13 +87,10 @@ def get_tests_committed(
 ) -> Set[str]:
     """Returns the test set from committed changes"""
     repo = get_git_repo()
-    current_hash = get_current_head_hash(repo)
-    changed_files = get_changed_files_between_commits(
-        repo, commithash_to_compare, current_hash
-    )
+    changed_files = get_changed_files_between_commits(repo, commithash_to_compare)
     file_diffs = {
         file_path: get_file_diff_data_between_commits(
-            repo, file_path, commithash_to_compare, current_hash
+            repo, file_path, commithash_to_compare
         )
         for file_path in changed_files
     }

--- a/pytest_rts/utils/git.py
+++ b/pytest_rts/utils/git.py
@@ -21,7 +21,7 @@ def get_changed_files_workdir(repo: GitRepository) -> List[str]:
 def get_changed_files_committed_and_workdir(
     repo: GitRepository, commithash_to_compare: str
 ) -> List[str]:
-    """Get changed files between given commit and Git HEAD"""
+    """Get changed files between given commit and the working copy"""
     return repo.repo.git.diff("--name-only", commithash_to_compare).split()
 
 
@@ -33,7 +33,7 @@ def get_file_diff_data_workdir(repo: GitRepository, file_path: str) -> str:
 def get_file_diff_data_committed_and_workdir(
     repo: GitRepository, file_path: str, commithash_to_compare: str
 ) -> str:
-    """Get git diff for a file from changes between two commits"""
+    """Get git diff for a file from changes between given commit and the working copy"""
     return repo.repo.git.diff("-U0", commithash_to_compare, "--", file_path)
 
 

--- a/pytest_rts/utils/git.py
+++ b/pytest_rts/utils/git.py
@@ -1,8 +1,10 @@
 """This module contains code for git operations"""
+import logging
 import re
 import subprocess
 from typing import List, Set
 
+from gitdb.exc import BadName
 from pydriller import GitRepository
 
 
@@ -10,7 +12,12 @@ def commit_exists(commithash: str, repo: GitRepository) -> bool:
     """Check if a given commithash exists in the Git repository"""
     if not commithash:
         return False
-    return commithash in [commit.hash for commit in repo.get_list_commits()]
+    try:
+        repo.get_commit(commithash)
+        return True
+    except BadName:
+        logging.info("Git commithash was provided but it was not found in history.")
+        return False
 
 
 def get_changed_files_workdir(repo: GitRepository) -> List[str]:

--- a/pytest_rts/utils/git.py
+++ b/pytest_rts/utils/git.py
@@ -17,10 +17,10 @@ def get_changed_files_current(repo: GitRepository) -> List[str]:
 
 
 def get_changed_files_between_commits(
-    repo: GitRepository, commithash1: str, commithash2: str
+    repo: GitRepository, commithash_to_compare: str
 ) -> List[str]:
-    """Get changed files between two commits"""
-    return repo.repo.git.diff("--name-only", commithash1, commithash2).split()
+    """Get changed files between given commit and Git HEAD"""
+    return repo.repo.git.diff("--name-only", commithash_to_compare, "HEAD").split()
 
 
 def get_file_diff_data_current(repo: GitRepository, file_path: str) -> str:
@@ -29,10 +29,10 @@ def get_file_diff_data_current(repo: GitRepository, file_path: str) -> str:
 
 
 def get_file_diff_data_between_commits(
-    repo: GitRepository, file_path: str, commithash1: str, commithash2: str
+    repo: GitRepository, file_path: str, commithash_to_compare: str
 ) -> str:
     """Get git diff for a file from changes between two commits"""
-    return repo.repo.git.diff("-U0", commithash1, commithash2, "--", file_path)
+    return repo.repo.git.diff("-U0", commithash_to_compare, "HEAD", "--", file_path)
 
 
 def get_changed_lines(diff: str) -> Set[int]:
@@ -62,11 +62,6 @@ def get_changed_lines(diff: str) -> Set[int]:
             changed_lines.update(range(int(old[0]), int(old[0]) + int(old[1])))
 
     return changed_lines
-
-
-def get_current_head_hash(repo: GitRepository) -> str:
-    """Return current git HEAD hash"""
-    return repo.repo.head.object.hexsha
 
 
 def get_git_repo() -> GitRepository:

--- a/pytest_rts/utils/git.py
+++ b/pytest_rts/utils/git.py
@@ -6,33 +6,35 @@ from typing import List, Set
 from pydriller import GitRepository
 
 
-def commit_exists(commithash: str) -> bool:
+def commit_exists(commithash: str, repo: GitRepository) -> bool:
     """Check if a given commithash exists in the Git repository"""
-    return commithash in [commit.hash for commit in get_git_repo().get_list_commits()]
+    if not commithash:
+        return False
+    return commithash in [commit.hash for commit in repo.get_list_commits()]
 
 
-def get_changed_files_current(repo: GitRepository) -> List[str]:
+def get_changed_files_workdir(repo: GitRepository) -> List[str]:
     """Get changed files in git working directory"""
     return repo.repo.git.diff("--name-only").split()
 
 
-def get_changed_files_between_commits(
+def get_changed_files_committed_and_workdir(
     repo: GitRepository, commithash_to_compare: str
 ) -> List[str]:
     """Get changed files between given commit and Git HEAD"""
-    return repo.repo.git.diff("--name-only", commithash_to_compare, "HEAD").split()
+    return repo.repo.git.diff("--name-only", commithash_to_compare).split()
 
 
-def get_file_diff_data_current(repo: GitRepository, file_path: str) -> str:
+def get_file_diff_data_workdir(repo: GitRepository, file_path: str) -> str:
     """Get git diff for a file in git working directory"""
     return repo.repo.git.diff("-U0", "--", file_path)
 
 
-def get_file_diff_data_between_commits(
+def get_file_diff_data_committed_and_workdir(
     repo: GitRepository, file_path: str, commithash_to_compare: str
 ) -> str:
     """Get git diff for a file from changes between two commits"""
-    return repo.repo.git.diff("-U0", commithash_to_compare, "HEAD", "--", file_path)
+    return repo.repo.git.diff("-U0", commithash_to_compare, "--", file_path)
 
 
 def get_changed_lines(diff: str) -> Set[int]:


### PR DESCRIPTION
Here's a version that can check tests from committed changes with `--rts-from-commit=[init commithash]`. If it's not provided, only changes in the working directory are checked. A slight problem is that new tests are discovered independently from the workdir/committed option and it would require some extra checking to get things perfectly right. 

Wrote some testcases for various situations. Also noticed that I created really flaky tests in the last PR because `__pycache__` files in the testrepo didn't update between runs. I think I fixed it by clearing them before each test. 